### PR TITLE
Line break inline code

### DIFF
--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -1138,7 +1138,7 @@ public struct MarkupFormatter: MarkupWalker {
     public mutating func visitInlineAttributes(_ attributes: InlineAttributes) {
         let savedState = state
         func printInlineAttributes() {
-            print("[", for: attributes)
+            print("^[", for: attributes)
             descendInto(attributes)
             print("](", for: attributes)
             print(attributes.attributes, for: attributes)
@@ -1152,7 +1152,7 @@ public struct MarkupFormatter: MarkupWalker {
         // gets into the realm of JSON formatting which might be out of scope of
         // this formatter. Therefore if exceeded, prefer to print it on the next
         // line to give as much opportunity to keep the attributes on one line.
-        if attributes.indexInParent > 0 && (isOverPreferredLineLimit || state.lineNumber > savedState.lineNumber) {
+        if attributes.indexInParent > 0 && (isOverPreferredLineLimit || state.effectiveLineNumber > savedState.effectiveLineNumber) {
             restoreState(to: savedState)
             queueNewline()
             printInlineAttributes()

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -347,6 +347,11 @@ public struct MarkupFormatter: MarkupWalker {
 
         /// The current line number.
         var lineNumber = 0
+
+        /// The "effective" line number, taking into account any queued newlines which have not been printed.
+        var effectiveLineNumber: Int {
+            lineNumber + queuedNewlines
+        }
     }
 
     /// The state of the formatter.
@@ -769,7 +774,7 @@ public struct MarkupFormatter: MarkupWalker {
         // If printing with automatic wrapping still put us over the line,
         // prefer to print it on the next line to give as much opportunity
         // to keep the contents on one line.
-        if inlineCode.indexInParent > 0 && (isOverPreferredLineLimit || state.lineNumber > savedState.lineNumber) {
+        if inlineCode.indexInParent > 0 && (isOverPreferredLineLimit || state.effectiveLineNumber > savedState.effectiveLineNumber) {
             restoreState(to: savedState)
             queueNewline()
             softWrapPrint("`\(inlineCode.code)`", for: inlineCode)

--- a/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
+++ b/Sources/Markdown/Walker/Walkers/MarkupFormatter.swift
@@ -805,7 +805,7 @@ public struct MarkupFormatter: MarkupWalker {
         // Image elements' source URLs can't be split. If wrapping the alt text
         // of an image still put us over the line, prefer to print it on the
         // next line to give as much opportunity to keep the alt text contents on one line.
-        if image.indexInParent > 0 && (isOverPreferredLineLimit || state.lineNumber > savedState.lineNumber) {
+        if image.indexInParent > 0 && (isOverPreferredLineLimit || state.effectiveLineNumber > savedState.effectiveLineNumber) {
             restoreState(to: savedState)
             queueNewline()
             printImage()
@@ -842,7 +842,7 @@ public struct MarkupFormatter: MarkupWalker {
             // Link elements' destination URLs can't be split. If wrapping the link text
             // of a link still put us over the line, prefer to print it on the
             // next line to give as much opportunity to keep the link text contents on one line.
-            if link.indexInParent > 0 && (isOverPreferredLineLimit || state.lineNumber > savedState.lineNumber) {
+            if link.indexInParent > 0 && (isOverPreferredLineLimit || state.effectiveLineNumber > savedState.effectiveLineNumber) {
                 restoreState(to: savedState)
                 queueNewline()
                 printRegularLink()

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -744,6 +744,24 @@ class MarkupFormatterSimpleRoundTripTests: XCTestCase {
         checkCharacterEquivalence(for: source)
     }
 
+    func testRoundTripHardBreakWithInlineAttribute() {
+        let source = """
+        This is some text.\("  ")
+        ^[This is some attributed text.](rainbow: 'extreme')
+        """
+        checkRoundTrip(for: source)
+        checkCharacterEquivalence(for: source)
+    }
+
+    func testRoundTripSoftBreakWithInlineAttribute() {
+        let source = """
+        This is some text.
+        ^[This is some attributed text.](rainbow: 'extreme')
+        """
+        checkRoundTrip(for: source)
+        checkCharacterEquivalence(for: source)
+    }
+
     /// Why not?
     func testRoundTripReadMe() throws {
         let readMeURL = URL(fileURLWithPath: #file)

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -690,6 +690,24 @@ class MarkupFormatterSimpleRoundTripTests: XCTestCase {
         checkCharacterEquivalence(for: source)
     }
 
+    func testRoundTripHardBreakWithInlineCode() {
+        let source = """
+        This is some text.\("  ")
+        `This is some code.`
+        """
+        checkRoundTrip(for: source)
+        checkCharacterEquivalence(for: source)
+    }
+
+    func testRoundTripSoftBreakWithInlineCode() {
+        let source = """
+        This is some text.
+        `This is some code.`
+        """
+        checkRoundTrip(for: source)
+        checkCharacterEquivalence(for: source)
+    }
+
     /// Why not?
     func testRoundTripReadMe() throws {
         let readMeURL = URL(fileURLWithPath: #file)

--- a/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
+++ b/Tests/MarkdownTests/Visitors/MarkupFormatterTests.swift
@@ -708,6 +708,42 @@ class MarkupFormatterSimpleRoundTripTests: XCTestCase {
         checkCharacterEquivalence(for: source)
     }
 
+    func testRoundTripHardBreakWithImage() {
+        let source = """
+        This is some text.\("  ")
+        ![This is an image.](image.png "")
+        """
+        checkRoundTrip(for: source)
+        checkCharacterEquivalence(for: source)
+    }
+
+    func testRoundTripSoftBreakWithImage() {
+        let source = """
+        This is some text.
+        ![This is an image.](image.png "")
+        """
+        checkRoundTrip(for: source)
+        checkCharacterEquivalence(for: source)
+    }
+
+    func testRoundTripHardBreakWithLink() {
+        let source = """
+        This is some text.\("  ")
+        [This is a link.](https://swift.org)
+        """
+        checkRoundTrip(for: source)
+        checkCharacterEquivalence(for: source)
+    }
+
+    func testRoundTripSoftBreakWithLink() {
+        let source = """
+        This is some text.
+        [This is a link.](https://swift.org)
+        """
+        checkRoundTrip(for: source)
+        checkCharacterEquivalence(for: source)
+    }
+
     /// Why not?
     func testRoundTripReadMe() throws {
         let readMeURL = URL(fileURLWithPath: #file)


### PR DESCRIPTION
https://github.com/apple/swift-markdown/pull/116

> Bug/issue #, if applicable: rdar://106915293
> 
> ## Summary
> When an inline code span, image, link, or inline attribute is written directly after a soft or hard line break, the MarkupFormatter incorrectly adds an extra line break before the latter item. This leads to Markdown in these situations being incorrectly round-tripped, because now there is a paragraph break that wasn't there before. This PR makes the MarkupFormatter consider queued newlines in these checks.
> 
> This also fixes an error in the MarkupFormatter output for inline attributes, which were previously missing the caret that denoted them as inline attributes instead of links.
> 
> ## Dependencies
> None
> 
> ## Testing
> Use the following markdown file:
> 
> ```gfm
> This is some text.
> `This is some code.`
> 
> This is some text.
> [This is a link.](https://swift.org)
> 
> This is some text.
> ![This is an image.](image.png)
> 
> This is some text.
> ^[This is some attributed text.](rainbow: 'extreme')
> ```
> 
> Steps:
> 
> 1. Save the previous Markdown as `test.md`.
> 2. `swift run markdown-tool format --check-structural-equivalence test.md`
> 3. Ensure that the rendered output contains only four paragraphs, and does not emit a "structural equivalence" warning.
> 
> ## Checklist
> Make sure you check off the following items. If they cannot be completed, provide a reason.
> 
> * [x]  Added tests
> * [x]  Ran the `./bin/test` script and it succeeded
> * [ n/a ] Updated documentation if necessary